### PR TITLE
docs(readme): add Foliofox to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,12 @@ Use React Server Components, trpc, or other strategies to maintain types.
   & longtime supporter.
 
 - 🛠️ [StockQuotes.MCP](https://github.com/lionelschiepers/StockQuotes.MCP) - AI
-  MCP Server to fetch real time financial data
+  MCP Server to fetch real time financial data.
 
 - ⚡ [live-quotes](https://github.com/mnsrulz/live-quotes) - Demo to showcase
   running yahoo-finance2 in cloudflare workers with live quotes.
+
+- 🦊 [Foliofox](https://www.foliofox.com/) - Open-source portfolio tracker with an AI financial advisor.
 
 Want your project listed? Open a PR to add it here.
 


### PR DESCRIPTION
## Summary

Adds Foliofox to the Related Projects section so yahoo-finance2 users can
discover an open-source portfolio tracker built with the library.

## Changes

- Added Foliofox to the README's Related Projects list.
- Added missing punctuation to the StockQuotes.MCP description.

## Verification

- [ ] `deno fmt --check`
- [ ] `deno lint`
- [ ] `deno task check`
- [ ] Relevant tests pass with `deno task test [path/to/test.ts]`
- [x] Schemas were regenerated with `deno task schema`, or exported interfaces
  are unchanged
- [x] HTTP fixtures were inspected, or fixtures are unchanged
- [x] Documentation and JSDoc were updated, or documentation is unchanged
- [x] Cloudflare tests pass with `deno task test:cloudflare`, or npm output and
  runtime behavior are unchanged

## Additional notes

Documentation-only change. Tests and Deno were not run.

Foliofox has used yahoo-finance2 since its earliest development, and I have
reported upstream issues with Node.js along the way :)
